### PR TITLE
update cpanmetadb url

### DIFF
--- a/lib/App/cpanlistchanges.pm
+++ b/lib/App/cpanlistchanges.pm
@@ -58,7 +58,7 @@ sub show_changes {
         $to = undef if $to eq 'HEAD';
     }
 
-    my $dist = try { YAML::Load( $self->get("http://cpanmetadb.appspot.com/v1.0/package/$mod") ) };
+    my $dist = try { YAML::Load( $self->get("http://cpanmetadb.plackperl.org/v1.0/package/$mod") ) };
     unless ($dist->{distfile}) {
         warn "Couldn't find a module '$mod'. Skipping.\n";
         return;


### PR DESCRIPTION
Hey @miyagawa,

http://cpanmetadb.appspot.com/ is no longer responding, which means every cpan-listchanges query results in "Couldn't find a module '$foo' .  Is http://cpanmetadb.plackperl.org/ the new canonical URL?  Thank you, and have a great day!

Cheers,
Fitz