### PR TITLE
fix URL to fetch Changes from

### DIFF
--- a/lib/App/cpanlistchanges.pm
+++ b/lib/App/cpanlistchanges.pm
@@ -87,12 +87,9 @@ sub show_changes {
 
     my $get_changes = sub {
         my $version = shift;
-        my $html = $self->get("http://search.cpan.org/dist/$info->{dist}-$version");
-        $html =~ s/&#(\d+);/chr $1/eg; # search.cpan.org seems to encode all filenames
-        $html =~ m!<a href="(/src/[^"]+)">(Change.*?)</a>!i or return;
-
-        my($url, $filename) = ($1, $2);
-        return $self->get("http://cpansearch.perl.org$1");
+        return $self->get(
+            "https://fastapi.metacpan.org/source/$info->{cpanid}/$info->{dist}-$version/Changes"
+        );
     };
 
     my $new_changes = $get_changes->($to);


### PR DESCRIPTION
Hey Miyagawa! Hope you're doing ok, and thanks again for yet-another-great-module :))

After [search.cpan.org started redirecting all traffic to metacpan.org](https://www.perl.com/article/saying-goodbye-to-search-cpan-org/), the URL to fetch Changes from on `cpan-listchanges` stopped working 😭 

Fortunately, metacpan has a very simple API and the update was pretty straightforward.

Hope this helps! Cheers!